### PR TITLE
power applet: Fix reported battery status

### DIFF
--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -423,14 +423,17 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
     }
 
     _getDeviceStatus(device) {
-        let status = ""
+        let status = "";
         let [device_id, vendor, model, device_type, icon, percentage, state, battery_level, seconds] = device;
 
         let time = Math.round(seconds / 60);
         let minutes = time % 60;
         let hours = Math.floor(time / 60);
 
-        if (state == UPDeviceState.CHARGING) {
+        if (state == UPDeviceState.UNKNOWN) {
+            status = "";
+        }
+        else if (state == UPDeviceState.CHARGING) {
             if (time == 0) {
                 status = _("Charging");
             }
@@ -451,7 +454,7 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
         else if (state == UPDeviceState.FULLY_CHARGED) {
             status = _("Fully charged");
         }
-        else {
+        else if (state == UPDeviceState.DISCHARGING) {
             if (time == 0) {
                 status = _("Using battery power");
             }
@@ -468,6 +471,12 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
             else {
                 status = ngettext("Using battery power - %d minute remaining", "Using battery power - %d minutes remaining", minutes).format(minutes);
             }
+        }
+        else if (state == UPDeviceState.EMPTY) {
+            status = _("Fully discharged");
+        }
+        else {
+            status = _("Not charging");
         }
 
         return status;


### PR DESCRIPTION
When the laptop battery is neither being charged nor discharged (eg: when a battery conservation mode is enabled, the AC adapter is plugged in, and the battery reached its intended charge level) the power applet incorrectly reports "Using battery power" when the laptop is actually running on AC power. It can also incorrectly report this when the battery state is actually unknown. This PR fixes that.

-----

Incidentally, i think the status "Using battery power" is incorrect and should just be "Charging". This line is the status of a particular battery (of which there could be many) and not the status of the PC. For all other status values the subject of the status phrase is the battery, but for this one the subject seems to be (incorrectly) the whole PC.

A status line could be added above the list of batteries in the popup that reflects the status of the whole PC ("Using battery power" vs "Using AC power"), but IMHO the status of each battery should just be "Charging".